### PR TITLE
WIP: Remove node:fs for WASM compatibility

### DIFF
--- a/lib/stringify/index.js
+++ b/lib/stringify/index.js
@@ -27,6 +27,7 @@ module.exports = function(node, options){
     ? new Compressed(options)
     : new Identity(options);
 
+/*
   // source maps
   if (options.sourcemap) {
     var sourcemaps = require('./source-map-support');
@@ -41,7 +42,7 @@ module.exports = function(node, options){
 
     return { code: code, map: map };
   }
-
+*/
   var code = compiler.compile(node);
   return code;
 };


### PR DESCRIPTION
To compile Enhance to wasm we need to remove node apis that are not supported. The parser has a node:fs import that is not needed for our use case. This temporary fix comments out a block of code containing the node:fs import. A more complete refactor may be needed.